### PR TITLE
Add verbose and normal formatters ; create the default log directory

### DIFF
--- a/yeti/log/.gitignore
+++ b/yeti/log/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/yeti/settings.py
+++ b/yeti/settings.py
@@ -178,6 +178,14 @@ LOG_DIRECTORY = os.path.join(SITE_ROOT, "log")
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+        },
+        'normal': {
+            'format': '%(levelname)s %(message)s'
+        },
+    },
     'filters': {
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse'


### PR DESCRIPTION
Add `verbose` and `normal` formatters:

```
$ python manage.py runserver
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 453, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 263, in fetch_command
    app_name = get_commands()[subcommand]
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 109, in get_commands
    apps = settings.INSTALLED_APPS
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 53, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 49, in _setup
    self._configure_logging()
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 84, in _configure_logging
    logging_config_func(self.LOGGING)
  File "/usr/lib/python2.7/logging/config.py", line 797, in dictConfig
    dictConfigClass(config).configure()
  File "/usr/lib/python2.7/logging/config.py", line 579, in configure
    '%r: %s' % (name, e))
ValueError: Unable to configure handler 'normal': Unable to set formatter 'verbose': 'verbose'
```

Create the default log directory:

```
python manage.py default
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 453, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 263, in fetch_command
    app_name = get_commands()[subcommand]
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 109, in get_commands
    apps = settings.INSTALLED_APPS
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 53, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 49, in _setup
    self._configure_logging()
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 84, in _configure_logging
    logging_config_func(self.LOGGING)
  File "/usr/lib/python2.7/logging/config.py", line 797, in dictConfig
    dictConfigClass(config).configure()
  File "/usr/lib/python2.7/logging/config.py", line 579, in configure
    '%r: %s' % (name, e))
ValueError: Unable to configure handler 'normal': [Errno 2] No such file or directory: '/home/yoyo/projects/yeti/yeti/log/yeti.log'
```
