### PR TITLE
Use argparse module instead of the deprecated optparse module. Check if tzinfo is present in the timestamp. Some PEP8

### DIFF
--- a/scripts/poll_client.py
+++ b/scripts/poll_client.py
@@ -4,7 +4,7 @@
 
 import sys
 
-from optparse import OptionParser
+import argparse
 import dateutil.parser
 
 import libtaxii as t
@@ -12,46 +12,47 @@ import libtaxii.messages as tm
 import libtaxii.clients as tc
 
 
-def main():    
-    parser = OptionParser()
-    parser.add_option("--host", dest="host", default="localhost", help="Host where the Poll Service is hosted. Defaults to localhost.")
-    parser.add_option("--port", dest="port", default="8080", help="Port where the Poll Service is hosted. Defaults to 8080.")
-    parser.add_option("--path", dest="path", default="/services/poll/", help="Path where the Poll Service is hosted. Defaults to /services/poll/.")
-    parser.add_option("--feed", dest="feed", default="default", help="Data Feed to poll. Defaults to 'default'.")
-    parser.add_option("--begin_timestamp", dest="begin_ts", default=None, help="The begin timestamp (format: YYYY-MM-DDTHH:MM:SS.ssssss+/-hh:mm) for the poll request. Defaults to None.")
-    parser.add_option("--end_timestamp", dest="end_ts", default=None, help="The end timestamp (format: YYYY-MM-DDTHH:MM:SS.ssssss+/-hh:mm) for the poll request. Defaults to None.")
+def main():
+    parser = argparse.ArgumentParser(description="Poll Client")
+    parser.add_argument("--host", dest="host", default="localhost", help="Host where the Poll Service is hosted. Defaults to localhost.")
+    parser.add_argument("--port", dest="port", default="8080", help="Port where the Poll Service is hosted. Defaults to 8080.")
+    parser.add_argument("--path", dest="path", default="/services/poll/", help="Path where the Poll Service is hosted. Defaults to /services/poll/.")
+    parser.add_argument("--feed", dest="feed", default="default", help="Data Feed to poll. Defaults to 'default'.")
+    parser.add_argument("--begin_timestamp", dest="begin_ts", default=None, help="The begin timestamp (format: YYYY-MM-DDTHH:MM:SS.ssssss+/-hh:mm) for the poll request. Defaults to None.")
+    parser.add_argument("--end_timestamp", dest="end_ts", default=None, help="The end timestamp (format: YYYY-MM-DDTHH:MM:SS.ssssss+/-hh:mm) for the poll request. Defaults to None.")
 
-    (options, args) = parser.parse_args()
-    
+    args = parser.parse_args()
+
     try:
-        begin_ts    = dateutil.parser.parse(options.begin_ts) if options.begin_ts else None
-        end_ts      = dateutil.parser.parse(options.end_ts) if options.end_ts else None
-    except ValueError as e:
+        if args.begin_ts:
+            begin_ts = dateutil.parser.parse(args.begin_ts)
+            if not begin_ts.tzinfo:
+                raise ValueError
+        else:
+            begin_ts = None
+
+        if args.end_ts:
+            end_ts = dateutil.parser.parse(args.end_ts)
+            if not end_ts.tzinfo:
+                raise ValueError
+        else:
+            end_ts = None
+    except ValueError:
         print "Unable to parse timestamp value. The format should be YYYY-MM-DDTHH:MM:SS.ssssss+/-hh:mm. Aborting poll."
         sys.exit()
-    
-    poll_req    = tm.PollRequest(message_id = tm.generate_message_id(),
-                                 feed_name = options.feed,
-                                 exclusive_begin_timestamp_label = begin_ts,
-                                 inclusive_end_timestamp_label = end_ts)
-    
+
+    poll_req = tm.PollRequest(message_id=tm.generate_message_id(),
+                              feed_name=args.feed,
+                              exclusive_begin_timestamp_label=begin_ts,
+                              inclusive_end_timestamp_label=end_ts)
+
     poll_req_xml = poll_req.to_xml()
     print "Poll Request: \r\n", poll_req_xml
     client = tc.HttpClient()
     client.setProxy('noproxy')
-    resp = client.callTaxiiService2(options.host, options.path, t.VID_TAXII_XML_10, poll_req_xml, options.port)
+    resp = client.callTaxiiService2(args.host, args.path, t.VID_TAXII_XML_10, poll_req_xml, args.port)
     response_message = t.get_message_from_http_response(resp, '0')
     print "Response Message: \r\n", response_message.to_xml()
 
 if __name__ == "__main__":
     main()
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
- [argparse](http://docs.python.org/2/library/optparse.html) is deprecated since version 2.7.
- Check if tzinfo is present in the timestamp to prevent this error : 

```
./poll_client.py --begin_timestamp "2009-08-18T13:52:54"
Traceback (most recent call last):
  File "./poll_client.py", line 50, in <module>
    main()
  File "./poll_client.py", line 39, in main
    inclusive_end_timestamp_label=end_ts)
  File "/home/yohann/.virtualenvs/yeti-test/src/libtaxii/libtaxii/messages.py", line 1370, in __init__
    raise ValueError('exclusive_begin_timestamp_label.tzinfo must not be None')
ValueError: exclusive_begin_timestamp_label.tzinfo must not be None

```
- Some PEP8.
